### PR TITLE
Added AES128-SHA256 cipher

### DIFF
--- a/roomba/src/client.rs
+++ b/roomba/src/client.rs
@@ -70,6 +70,7 @@ impl Client {
 
         let mut builder = SslConnector::builder(SslMethod::tls())?;
         builder.set_verify(SslVerifyMode::NONE);
+        builder.set_cipher_list("AES128-SHA256").unwrap();
         let connector = builder.build();
 
         let uri = format!("{}:8883", hostname.as_ref());

--- a/roomba/src/client.rs
+++ b/roomba/src/client.rs
@@ -70,7 +70,7 @@ impl Client {
 
         let mut builder = SslConnector::builder(SslMethod::tls())?;
         builder.set_verify(SslVerifyMode::NONE);
-        builder.set_cipher_list("AES128-SHA256").unwrap();
+        builder.set_cipher_list("DEFAULT:!DH").unwrap();
         let connector = builder.build();
 
         let uri = format!("{}:8883", hostname.as_ref());


### PR DESCRIPTION
Partial fix for #7. Not sure how this impacts other roombas but mine wouldn't connect without this cipher.

https://stackoverflow.com/questions/36417224/openssl-dh-key-too-small-error/36417794#36417794 suggests `DEFAULT:!DH`, but this is what [dorita980](https://github.com/koalazak/dorita980/blob/master/bin/getpassword.js#L91) does